### PR TITLE
Fix crash in Contoso.Forms.Puppet UWP

### DIFF
--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/AddPropertyContentPage.xaml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/AddPropertyContentPage.xaml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Contoso.Forms.Puppet.AddPropertyContentPage">
-	<TableView Intent="Form">
-		<TableSection>
-			<EntryCell Label="Property Name" x:Name="NameCell"/>
-			<EntryCell Label="Property Value" x:Name="ValueCell"/>
-			<ViewCell Tapped="AddProperty">
-				<Button Text="Add Property" InputTransparent="true" Clicked="AddProperty" />
-			</ViewCell>
-			<ViewCell Tapped="Cancel">
-				<Button Text="Cancel" InputTransparent="true" TextColor="Red" Clicked="Cancel"/>
-			</ViewCell>
-		</TableSection>
-	</TableView>
+  <StackLayout Padding="20">
+    <StackLayout Orientation="Horizontal">
+      <Label Text="Property Name" HorizontalOptions="Start" VerticalOptions="Center" WidthRequest="120" />
+      <Entry HorizontalOptions="FillAndExpand" x:Name="NameEntry" />
+    </StackLayout>
+    <StackLayout Orientation="Horizontal">
+      <Label Text="Property Value" HorizontalOptions="Start" VerticalOptions="Center" WidthRequest="120" />
+      <Entry HorizontalOptions="FillAndExpand" x:Name="ValueEntry" />
+    </StackLayout>
+    <Button Text="Add Property" Clicked="AddProperty" />
+    <Button Text="Cancel" TextColor="Red" Clicked="Cancel" />
+  </StackLayout>
 </ContentPage>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/AddPropertyContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/AddPropertyContentPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Contoso.Forms.Puppet
 
         async void AddProperty(object sender, EventArgs e)
         {
-            Property addedProperty = new Property(NameCell?.Text, ValueCell?.Text);
+            Property addedProperty = new Property(NameEntry?.Text, ValueEntry?.Text);
             PropertyAdded?.Invoke(addedProperty);
             await Navigation.PopModalAsync();
         }


### PR DESCRIPTION
Contoso.Forms.Puppet crashed in UWP when user open the Analytics tab and try to add a property.

I opened issue in Xamarin.Forms for crash when Navigation.PopModalAsync called on page with TableView.
For temp workaround for the crash, TableView replaced to StackLayout.