### PR TITLE
Move to iOS SDK 0.5.0

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/ApiDefinition.cs
@@ -150,10 +150,10 @@ namespace Microsoft.Azure.Mobile.iOS.Bindings
         [Export("isConfigured")]
         bool IsConfigured();
 
-        // +(void)setServerUrl:(NSString *)serverUrl;
+        // +(void)setLogUrl:(NSString *)setLogUrl;
         [Static]
-        [Export("setServerUrl:")]
-        void SetServerUrl(string serverUrl);
+        [Export("setLogUrl:")]
+        void SetLogUrl(string logUrl);
 
         // +(void)setEnabled:(BOOL)isEnabled;
         [Static]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/MobileCenter.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Mobile
         /// <param name="logUrl">base log URL.</param>
         public static void SetLogUrl(string logUrl)
         {
-            iOSMobileCenter.SetServerUrl(logUrl);
+            iOSMobileCenter.SetLogUrl(logUrl);
         }
 
         /// <summary>

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/ApiDefinition.cs
@@ -97,6 +97,10 @@ namespace Microsoft.Azure.Mobile.Crashes.iOS.Bindings
         [Static]
         [Export("notifyWithUserConfirmation:")]
         void NotifyWithUserConfirmation(MSUserConfirmation userConfirmation);
+
+        [Static]
+        [Export("notifyPermanentlyDisableMachExceptionHandling")]
+        void NotifyPermanentlyDisableMachExceptionHandling();
     }
 
     // @protocol MSCrashesDelegate <NSObject>

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/PlatformCrashes.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/PlatformCrashes.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Azure.Mobile.Crashes
 
         public PlatformCrashes()
         {
+            MSCrashes.NotifyPermanentlyDisableMachExceptionHandling();
             MSCrashes.SetUserConfirmationHandler((arg0) =>
                     {
                         if (ShouldAwaitUserConfirmation != null)

--- a/build.cake
+++ b/build.cake
@@ -20,7 +20,7 @@ class MobileCenterModule {
 
 // SDK versions
 var ANDROID_SDK_VERSION = "0.5.0";
-var IOS_SDK_VERSION = "0.4.1";
+var IOS_SDK_VERSION = "0.4.2";
 
 // URLs for downloading binaries.
 /*

--- a/build.cake
+++ b/build.cake
@@ -20,7 +20,7 @@ class MobileCenterModule {
 
 // SDK versions
 var ANDROID_SDK_VERSION = "0.5.0";
-var IOS_SDK_VERSION = "0.4.2";
+var IOS_SDK_VERSION = "0.5.0";
 
 // URLs for downloading binaries.
 /*


### PR DESCRIPTION
@achocron Don't merge label: by updating bindings we can't attach the .NET exception to the apple crash anymore. I have no idea why, needs investigation.