### PR TITLE
Treat 401 as unrecoverable error

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Ingestion/Http/IngestionHttp.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Ingestion/Http/IngestionHttp.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Mobile.Ingestion.Http
             get
             {
                 var statusCode = (int)StatusCode;
-                return statusCode >= 501 || statusCode == 408 || statusCode == 429 || statusCode == 401;
+                return statusCode >= 501 || statusCode == 408 || statusCode == 429;
             }
         }
 


### PR DESCRIPTION
401 response code is now considered as unrecoverable error.