### PR TITLE
Show a warning that we don't support UWP crashes

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/WatsonCrashesStarter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/WatsonCrashesStarter.cs
@@ -21,7 +21,11 @@ namespace Microsoft.Azure.Mobile.Utils
             }
             catch (Exception e)
             {
+#if DEBUG
                 throw new MobileCenterException("Failed to register crashes with Watson", e);
+#else
+                MobileCenterLog.Warn(MobileCenterLog.LogTag, "Crashes service is not yet supported on UWP.");
+#endif
             }
         }
     }


### PR DESCRIPTION
Instead of an exception that we need when debugging SDK while developing.