### PR TITLE
Fix a deprecation warning of TargetPlatform.iOS in Demo app

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AnalyticsContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AnalyticsContentPage.xaml.cs
@@ -27,7 +27,7 @@ namespace Contoso.Forms.Demo
             InitializeComponent();
             EventProperties = new List<Property>();
             NumPropertiesLabel.Text = EventProperties.Count.ToString();
-            if (Xamarin.Forms.Device.OS == TargetPlatform.iOS)
+            if (Xamarin.Forms.Device.RuntimePlatform == Xamarin.Forms.Device.iOS)
             {
                 Icon = "lightning.png";
             }

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Contoso.Forms.Demo
         public CrashesContentPage()
         {
             InitializeComponent();
-            if (Xamarin.Forms.Device.OS == TargetPlatform.iOS)
+            if (Xamarin.Forms.Device.RuntimePlatform == Xamarin.Forms.Device.iOS)
             {
                 Icon = "socket.png";
             }

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/MobileCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/MobileCenterContentPage.xaml.cs
@@ -9,7 +9,7 @@ namespace Contoso.Forms.Demo
         public MobileCenterContentPage()
         {
             InitializeComponent();
-            if (Xamarin.Forms.Device.OS == TargetPlatform.iOS)
+            if (Xamarin.Forms.Device.RuntimePlatform == Xamarin.Forms.Device.iOS)
             {
                 Icon = "bolt.png";
             }


### PR DESCRIPTION
I fixed the same in Puppet app earlier today. Now fix it in Demo.