### PR TITLE
Fixed instability in unit tests

### DIFF
--- a/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/SessionTrackerTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/SessionTrackerTest.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Azure.Mobile.Analytics.Test.Windows
             _mockChannelGroup.Setup(
                     group => group.AddChannel(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TimeSpan>(), It.IsAny<int>()))
                 .Returns(_mockChannel.Object);
+            ApplicationSettings.Reset();
             _sessionTracker = new SessionTracker(_mockChannelGroup.Object, _mockChannel.Object);
             SessionTracker.SessionTimeout = 500;
-            ApplicationSettings.Reset();
         }
 
         /// <summary>


### PR DESCRIPTION
Some of the unit tests were failing inconsistently. These errors were hard to reproduce on a local machine as they have mostly been observed in VSTS. I think the problem was that during SessionTracker initialization, it was loading state from previous test methods through ApplicationSettings. 