### PR TITLE
Point UWP.Puppet app to INT environment

### DIFF
--- a/Apps/Contoso.UWP.Puppet/App.xaml.cs
+++ b/Apps/Contoso.UWP.Puppet/App.xaml.cs
@@ -24,6 +24,7 @@ namespace Contoso.UWP.Puppet
         {
             MobileCenter.LogLevel = LogLevel.Verbose;
             MobileCenter.Configure("42f4a839-c54c-44da-8072-a2f2a61751b2");
+            MobileCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
             Analytics.Enabled = true;
             MobileCenter.Start(typeof(Analytics), typeof(Crashes));
             MobileCenter.Enabled = true;


### PR DESCRIPTION
MobileCenter UWP puppet app "42f4a839-c54c-44da-8072-a2f2a61751b2" lives in INT environment. 