### PR TITLE
Bump to version 0.9.0

### DIFF
--- a/Apps/Contoso.Android.Puppet/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Android.Puppet/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.azure.mobile.xamarin.puppet" android:versionCode="11" android:versionName="0.8.2-SNAPSHOT" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.azure.mobile.xamarin.puppet" android:versionCode="12" android:versionName="0.9.0-SNAPSHOT" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="SXPuppet" android:icon="@drawable/Icon"></application>
 </manifest>

--- a/Apps/Contoso.Android.Puppet/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Android.Puppet/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="11" android:versionName="0.8.2-SNAPSHOT" package="com.microsoft.azure.mobile.xamarin.forms.puppet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="12" android:versionName="0.9.0-SNAPSHOT" package="com.microsoft.azure.mobile.xamarin.forms.puppet">
 	<uses-sdk android:minSdkVersion="15" />
 	<application android:label="MCFPuppet"></application>
 </manifest>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AssemblyInfo.cs
@@ -19,8 +19,8 @@ using Android.App;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Package.appxmanifest
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Package.appxmanifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="2a16a451-5df0-42b2-941c-dafeed006a2e" Publisher="CN=MS1" Version="0.8.2.0" />
+  <Identity Name="2a16a451-5df0-42b2-941c-dafeed006a2e" Publisher="CN=MS1" Version="0.9.0.0" />
   <mp:PhoneIdentity PhoneProductId="2a16a451-5df0-42b2-941c-dafeed006a2e" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Contoso.Forms.Puppet.UWP</DisplayName>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
 [assembly: ComVisible(false)]

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/Info.plist
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/Info.plist
@@ -5,9 +5,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.microsoft.azure.mobile.xamarin.forms.puppet</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.2</string>
+	<string>0.9.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.2</string>
+	<string>0.9.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Apps/Contoso.UWP.Puppet/Package.appxmanifest
+++ b/Apps/Contoso.UWP.Puppet/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="d7caa89c-60ad-439a-9c1a-95182d6f490d"
     Publisher="CN=alchocro"
-    Version="0.8.2.0" />
+    Version="0.9.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="d7caa89c-60ad-439a-9c1a-95182d6f490d" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/Apps/Contoso.UWP.Puppet/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.UWP.Puppet/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
 [assembly: ComVisible(false)]

--- a/Apps/Contoso.iOS.Puppet/Info.plist
+++ b/Apps/Contoso.iOS.Puppet/Info.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.microsoft.azure.mobile.xamarin.puppet</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.2</string>
+	<string>0.9.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.2</string>
+	<string>0.9.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Android.Bindings/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Shared/WrapperSdk.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Shared/WrapperSdk.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Azure.Mobile
         public const string Name = "mobilecenter.xamarin";
 
         /* We can't use reflection for assemblyInformationalVersion on iOS with "Link All" optimization. */
-        internal const string Version = "0.8.2-SNAPSHOT";
+        internal const string Version = "0.9.0-SNAPSHOT";
     }
 }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 [assembly: ComVisible(false)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Mobile.Test.UWP")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using Foundation;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Resources;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Android.Bindings/Properties/AssemblyInfo.cs
@@ -18,8 +18,8 @@ using System.Runtime.InteropServices;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.UWP/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.UWP/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
 [assembly: ComVisible(false)]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using Foundation;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Resources;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android.Bindings/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.UWP/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.UWP/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 [assembly: ComVisible(false)]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.Android.Bindings/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using Foundation;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.iOS/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/Tests/Contoso.Forms.Test/Properties/AssemblyInfo.cs
+++ b/Tests/Contoso.Forms.Test/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Tests/Droid/Properties/AndroidManifest.xml
+++ b/Tests/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="10" android:versionName="0.8.2-SNAPSHOT" package="com.contoso.contoso_forms_test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="11" android:versionName="0.9.0-SNAPSHOT" package="com.contoso.contoso_forms_test">
     <uses-sdk android:minSdkVersion="15" />
     <application android:label="Contoso.Forms.Test">
     </application>

--- a/Tests/Droid/Properties/AssemblyInfo.cs
+++ b/Tests/Droid/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Tests/Microsoft.Azure.Mobile.Analytics.NET/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.Azure.Mobile.Analytics.NET/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.Mobile.Analytics.Test.Windows")]

--- a/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/Properties/AssemblyInfo.cs
@@ -16,5 +16,5 @@ using System.Runtime.InteropServices;
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/Tests/Microsoft.Azure.Mobile.NET/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.Azure.Mobile.NET/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.Mobile.Test.Windows")]

--- a/Tests/Microsoft.Azure.Mobile.Test.Windows/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.Windows/Properties/AssemblyInfo.cs
@@ -16,5 +16,5 @@ using System.Runtime.InteropServices;
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
-[assembly: AssemblyInformationalVersion("0.8.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-SNAPSHOT")]

--- a/Tests/iOS/Info.plist
+++ b/Tests/iOS/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.contoso.contoso-forms-test</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.2</string>
+	<string>0.9.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.2</string>
+	<string>0.9.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>


### PR DESCRIPTION
Watson changes nuget structure and support more architectures, thus next release is not a bugfix release. So need to bump minor.