### PR TITLE
Fixed Xamarin Distribute delegate

### DIFF
--- a/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.Android/Distribute.cs
+++ b/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.Android/Distribute.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Mobile.Distribute
                     };
                     return _releaseAvailableCallback(releaseDetails);
                 }
-                return true;
+                return false;
             }
         }
     }

--- a/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.iOS/Distribute.cs
+++ b/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute.iOS/Distribute.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Mobile.Distribute
                     };
                     return _releaseAvailableCallback(releaseDetails);
                 }
-                return true;
+                return false;
             }
         }
     }


### PR DESCRIPTION
Android and iOS distribute delegates now return false in case callback is set to null to show default update dialog.