### PR TITLE
[UWP] Includes push register as part of MobileCenter.Start()

### DIFF
--- a/Apps/Contoso.UWP.Puppet/App.xaml.cs
+++ b/Apps/Contoso.UWP.Puppet/App.xaml.cs
@@ -83,8 +83,6 @@ namespace Contoso.UWP.Puppet
                 // Ensure the current window is active
                 Window.Current.Activate();
             }
-
-            Push.Register();
         }
 
         /// <summary>

--- a/SDK/MobileCenterPush/Microsoft.Azure.Mobile.Push.UWP/Push.cs
+++ b/SDK/MobileCenterPush/Microsoft.Azure.Mobile.Push.UWP/Push.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Azure.Mobile.Push
 {
     public partial class Push : MobileCenterService
     {
+        // Retrieve the push token from platform-specific Push Notification Service,
+        // and later use the token to register with Mobile Center backend.
         private void InstanceRegister()
         {
             if (!Enabled)

--- a/SDK/MobileCenterPush/Microsoft.Azure.Mobile.Push.Windows.Shared/Push.cs
+++ b/SDK/MobileCenterPush/Microsoft.Azure.Mobile.Push.Windows.Shared/Push.cs
@@ -45,15 +45,6 @@ namespace Microsoft.Azure.Mobile.Push
             }
         }
 
-        /// <summary>
-        /// Retrieve the push token from platform-specific Push Notification Service,
-        /// and later use the token to register with Mobile Center backend.
-        /// </summary>
-        public static void Register()
-        {
-            Instance.InstanceRegister();
-        }
-
         #endregion
 
         #region instance
@@ -91,6 +82,8 @@ namespace Microsoft.Azure.Mobile.Push
         public override void OnChannelGroupReady(IChannelGroup channelGroup)
         {
             base.OnChannelGroupReady(channelGroup);
+
+            Instance.InstanceRegister();
         }
 
         public override bool InstanceEnabled


### PR DESCRIPTION
Problem description: Push.Register() should be included as part of the MobileCenter.Start() startup of Push service. Current implementation requires developer to call Push.Register() separately.

Solution: Includes Register() in Push service startup. I've e2e tested this on UWP desktop and UWP phone.