### PR TITLE
Fixes test VerifyPlatformId

### DIFF
--- a/Tests/Microsoft.Azure.Mobile.Test.UWP/MobileCenterTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.UWP/MobileCenterTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Azure.Mobile.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.ApplicationModel.Core;
 
 namespace Microsoft.Azure.Mobile.Test.UWP
 {
@@ -19,7 +20,11 @@ namespace Microsoft.Azure.Mobile.Test.UWP
         [TestMethod]
         public void VerifyPlatformId()
         {
-            MobileCenter.Configure("uwp=appsecret");
+            CoreApplication.MainView.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                MobileCenter.Configure("uwp=appsecret");
+            }).AsTask().GetAwaiter().GetResult();
+
             Assert.IsTrue(MobileCenter.Configured);
         }
 

--- a/Tests/Microsoft.Azure.Mobile.Test.UWP/Utils/DeviceInformationHelperTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.UWP/Utils/DeviceInformationHelperTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Azure.Mobile.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Mobile.Test.UWP.Utils
 {
@@ -12,7 +13,7 @@ namespace Microsoft.Azure.Mobile.Test.UWP.Utils
         [TestMethod]
         public void VerifySdkName()
         {
-            var device = new DeviceInformationHelper().GetDeviceInformation();
+            var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
             Assert.AreEqual(device.SdkName, "mobilecenter.uwp");
         }
 
@@ -25,7 +26,7 @@ namespace Microsoft.Azure.Mobile.Test.UWP.Utils
             const string CountryCode = "US";
             MobileCenter.SetCountryCode(CountryCode);
 
-            var device = new DeviceInformationHelper().GetDeviceInformation();
+            var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
             Assert.AreEqual(device.CarrierCountry, CountryCode);
         }
     }

--- a/Tests/Microsoft.Azure.Mobile.Test.UWP/project.json
+++ b/Tests/Microsoft.Azure.Mobile.Test.UWP/project.json
@@ -1,8 +1,8 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "MSTest.TestAdapter": "1.1.11",
-    "MSTest.TestFramework": "1.1.11"
+    "MSTest.TestAdapter": "1.1.17",
+    "MSTest.TestFramework": "1.1.17"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
Actually there is an attribute [UITestMethod] for such cases, but there was a bug with tests discovery using this attribute in MSTest version 1.1.11. ([See here](https://github.com/Microsoft/testfx/issues/76)) But even after increasing version to 1.1.17 bug remained and tests were not discovered.