### PR TITLE
Fixes incorrect fields in device info

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.WinForms/Utils/DeviceInformationHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.WinForms/Utils/DeviceInformationHelper.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Mobile.Utils
             var managementClass = new ManagementClass("Win32_OperatingSystem");
             foreach (var managementObject in managementClass.GetInstances())
             {
-                return $"{(string)managementObject["Version"]}.{(string)managementObject["BuildNumber"]}";
+                return $"{(string)managementObject["Version"]}.{Environment.OSVersion.Version.Revision}";
             }
             return string.Empty;
         }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.WinForms/Utils/DeviceInformationHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.WinForms/Utils/DeviceInformationHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Management;
 using System.Reflection;
 using System.Windows.Forms;
@@ -11,7 +12,7 @@ namespace Microsoft.Azure.Mobile.Utils
     public class DeviceInformationHelper : AbstractDeviceInformationHelper
     {
         public static event EventHandler InformationInvalidated;
-        
+
         protected override string GetSdkName()
         {
             return "mobilecenter.winforms";
@@ -44,19 +45,32 @@ namespace Microsoft.Azure.Mobile.Utils
 
         protected override string GetOsName()
         {
-            return Environment.OSVersion.Platform.ToString();
+            var managementClass = new ManagementClass("Win32_OperatingSystem");
+            foreach (var managementObject in managementClass.GetInstances())
+            {
+                return (string)managementObject["Caption"];
+            }
+            return string.Empty;
         }
 
         protected override string GetOsBuild()
         {
-            var version = Environment.OSVersion.Version;
-            return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
+            var managementClass = new ManagementClass("Win32_OperatingSystem");
+            foreach (var managementObject in managementClass.GetInstances())
+            {
+                return $"{(string)managementObject["Version"]}.{(string)managementObject["BuildNumber"]}";
+            }
+            return string.Empty;
         }
 
         protected override string GetOsVersion()
         {
-            var version = Environment.OSVersion.Version;
-            return $"{version.Major}.{version.Minor}.{version.Build}";
+            var managementClass = new ManagementClass("Win32_OperatingSystem");
+            foreach (var managementObject in managementClass.GetInstances())
+            {
+                return (string)managementObject["Version"];
+            }
+            return string.Empty;
         }
 
         protected override string GetAppVersion()
@@ -70,9 +84,22 @@ namespace Microsoft.Azure.Mobile.Utils
         }
 
         protected override string GetScreenSize()
-        {
-            var size = SystemInformation.PrimaryMonitorSize;
-            return $"{size.Width}x{size.Height}";
+        {          
+            const int DESKTOPVERTRES = 117;
+            const int DESKTOPHORZRES = 118;
+            using (Graphics graphics = Graphics.FromHwnd(IntPtr.Zero))
+            {
+                IntPtr desktop = graphics.GetHdc();
+                int height = GetDeviceCaps(desktop, DESKTOPVERTRES);
+                int width = GetDeviceCaps(desktop, DESKTOPHORZRES);
+                return $"{width}x{height}";
+            }
         }
+
+        /*
+         * Import GetDeviceCaps function to retreive scale-independent screen size.
+         */
+        [System.Runtime.InteropServices.DllImport("gdi32.dll")]
+        static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
     }
 }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.WinForms/Utils/DeviceInformationHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.WinForms/Utils/DeviceInformationHelper.cs
@@ -88,11 +88,11 @@ namespace Microsoft.Azure.Mobile.Utils
         {          
             const int DESKTOPVERTRES = 117;
             const int DESKTOPHORZRES = 118;
-            using (Graphics graphics = Graphics.FromHwnd(IntPtr.Zero))
+            using (var graphics = Graphics.FromHwnd(IntPtr.Zero))
             {
-                IntPtr desktop = graphics.GetHdc();
-                int height = GetDeviceCaps(desktop, DESKTOPVERTRES);
-                int width = GetDeviceCaps(desktop, DESKTOPHORZRES);
+                var desktop = graphics.GetHdc();
+                var height = GetDeviceCaps(desktop, DESKTOPVERTRES);
+                var width = GetDeviceCaps(desktop, DESKTOPHORZRES);
                 return $"{width}x{height}";
             }
         }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.WinForms/Utils/DeviceInformationHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.WinForms/Utils/DeviceInformationHelper.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Management;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace Microsoft.Azure.Mobile.Utils
@@ -96,10 +97,10 @@ namespace Microsoft.Azure.Mobile.Utils
             }
         }
 
-        /*
-         * Import GetDeviceCaps function to retreive scale-independent screen size.
-         */
-        [System.Runtime.InteropServices.DllImport("gdi32.dll")]
+        /// <summary>
+        /// Import GetDeviceCaps function to retreive scale-independent screen size.
+        /// </summary>
+        [DllImport("gdi32.dll")]
         static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
     }
 }


### PR DESCRIPTION
Problem with GetScreenSize method was, that if user had scaling factor other than 100% it reported wrong screen sizes. 
Also according to documentation there is no way to get a OS revision (like in UWP) from ManagementClass Win32_OperatingSystem, so i'm currently using Environment.OSVersion.Version.Revision value