### PR TITLE
Hide MobileCenterLog from intellisense

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Shared/MobileCenterLogShared.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Shared/MobileCenterLogShared.cs
@@ -1,70 +1,88 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace Microsoft.Azure.Mobile
 {
+    /// <summary>
+    /// This class is used to log messages consistent with those emitted by the SDK.
+    /// Note: To track events, use <code>Analytics.TrackEvent</code>.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static partial class MobileCenterLog
     {
         /// <summary>
-        /// Writes a log and an exception at the <see cref="LogLevel.Verbose"/> level. 
+        /// Writes a log and an exception at the <see cref="LogLevel.Verbose"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
         /// <param name="exception">Associated exception.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Verbose(string tag, string message, Exception exception)
         {
             Verbose(tag, ConcatMessageException(message, exception));
         }
 
         /// <summary>
-        /// Writes a log and an exception at the <see cref="LogLevel.Debug"/> level. 
+        /// Writes a log and an exception at the <see cref="LogLevel.Debug"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
         /// <param name="exception">Associated exception.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Debug(string tag, string message, Exception exception)
         {
             Debug(tag, ConcatMessageException(message, exception));
         }
 
         /// <summary>
-        /// Writes a log and an exception at the <see cref="LogLevel.Info"/> level. 
+        /// Writes a log and an exception at the <see cref="LogLevel.Info"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
         /// <param name="exception">Associated exception.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Info(string tag, string message, Exception exception)
         {
             Info(tag, ConcatMessageException(message, exception));
         }
 
         /// <summary>
-        /// Writes a log and an exception at the <see cref="LogLevel.Warn"/> level. 
+        /// Writes a log and an exception at the <see cref="LogLevel.Warn"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
         /// <param name="exception">Associated exception.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Warn(string tag, string message, Exception exception)
         {
             Warn(tag, ConcatMessageException(message, exception));
         }
 
         /// <summary>
-        /// Writes a log and an exception at the <see cref="LogLevel.Error"/> level. 
+        /// Writes a log and an exception at the <see cref="LogLevel.Error"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
         /// <param name="exception">Associated exception.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Error(string tag, string message, Exception exception)
         {
             Error(tag, ConcatMessageException(message, exception));
         }
 
         /// <summary>
-        /// Writes a log and an exception at the <see cref="LogLevel.Assert"/> level. 
+        /// Writes a log and an exception at the <see cref="LogLevel.Assert"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
         /// <param name="exception">Associated exception.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Assert(string tag, string message, Exception exception)
         {
             Assert(tag, ConcatMessageException(message, exception));

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterLog.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterLog.cs
@@ -1,4 +1,5 @@
 ﻿#define DEBUG
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace Microsoft.Azure.Mobile
@@ -8,6 +9,7 @@ namespace Microsoft.Azure.Mobile
         /// <summary>
         /// The log tag for this SDK. All logs emitted at the SDK level will contain this tag.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static string LogTag { get; private set; }
         private static readonly object LogLock = new object();
         private static LogLevel _level = LogLevel.Assert;
@@ -15,6 +17,7 @@ namespace Microsoft.Azure.Mobile
         /// <summary>
         /// Gets or sets the log verbosity level.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         internal static LogLevel Level
         {
             get
@@ -39,60 +42,72 @@ namespace Microsoft.Azure.Mobile
         }
 
         /// <summary>
-        /// Emits a log at the <see cref="LogLevel.Verbose"/> level.
+        /// Writes a log at the <see cref="LogLevel.Verbose"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">The log tag</param>
         /// <param name="message">The message to log</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Verbose(string tag, string message)
         {
             LogMessage(tag, message, LogLevel.Verbose, "VERBOSE");
         }
 
         /// <summary>
-        /// Emits a log at the <see cref="LogLevel.Debug"/> level.
+        /// Writes a log at the <see cref="LogLevel.Debug"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">The log tag</param>
         /// <param name="message">The message to log</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Debug(string tag, string message)
         {
             LogMessage(tag, message, LogLevel.Debug, "DEBUG");
         }
 
         /// <summary>
-        /// Emits a log at the <see cref="LogLevel.Info"/> level.
+        /// Writes a log at the <see cref="LogLevel.Info"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">The log tag</param>
         /// <param name="message">The message to log</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Info(string tag, string message)
         {
             LogMessage(tag, message, LogLevel.Info, "INFO");
         }
 
         /// <summary>
-        /// Emits a log at the <see cref="LogLevel.Warn"/> level.
+        /// Writes a log at the <see cref="LogLevel.Warn"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">The log tag</param>
         /// <param name="message">The message to log</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Warn(string tag, string message)
         {
             LogMessage(tag, message, LogLevel.Warn, "WARN");
         }
 
         /// <summary>
-        /// Emits a log at the <see cref="LogLevel.Error"/> level.
+        /// Writes a log at the <see cref="LogLevel.Error"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">The log tag</param>
         /// <param name="message">The message to log</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Error(string tag, string message)
         {
             LogMessage(tag, message, LogLevel.Error, "ERROR");
         }
 
         /// <summary>
-        /// Emits a log at the <see cref="LogLevel.Assert"/> level.
+        /// Writes a log at the <see cref="LogLevel.Assert"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">The log tag</param>
         /// <param name="message">The message to log</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Assert(string tag, string message)
         {
             LogMessage(tag, message, LogLevel.Assert, "ASSERT");

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterLog.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterLog.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.Mobile
         /// <summary>
         /// Gets or sets the log verbosity level.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         internal static LogLevel Level
         {
             get

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile/MobileCenterLog.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile/MobileCenterLog.cs
@@ -1,65 +1,77 @@
-﻿namespace Microsoft.Azure.Mobile
+﻿using System.ComponentModel;
+
+namespace Microsoft.Azure.Mobile
 {
-    /// <summary>
-    /// This class is used to log messages consistent with those emitted by the SDK.
-    /// </summary>
     public static partial class MobileCenterLog
     {
         /// <summary>
         /// The log tag for this SDK. All logs emitted at the SDK level will contain this tag.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static string LogTag { get; private set; }
 
         /// <summary>
-        /// Writes a log at the <see cref="LogLevel.Verbose"/> level. 
+        /// Writes a log at the <see cref="LogLevel.Verbose"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Verbose(string tag, string message)
         {
         }
 
         /// <summary>
-        /// Writes a log at the <see cref="LogLevel.Debug"/> level. 
+        /// Writes a log at the <see cref="LogLevel.Debug"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Debug(string tag, string message)
         {
         }
 
         /// <summary>
-        /// Writes a log at the <see cref="LogLevel.Info"/> level. 
+        /// Writes a log at the <see cref="LogLevel.Info"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Info(string tag, string message)
         {
         }
 
         /// <summary>
-        /// Writes a log at the <see cref="LogLevel.Warn"/> level. 
+        /// Writes a log at the <see cref="LogLevel.Warn"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Warn(string tag, string message)
         {
         }
 
         /// <summary>
-        /// Writes a log at the <see cref="LogLevel.Error"/> level. 
+        /// Writes a log at the <see cref="LogLevel.Error"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Error(string tag, string message)
         {
         }
 
         /// <summary>
-        /// Writes a log at the <see cref="LogLevel.Assert"/> level. 
+        /// Writes a log at the <see cref="LogLevel.Assert"/> level.
+        /// Note: To track events, use <code>Analytics.TrackEvent</code>.
         /// </summary>
         /// <param name="tag">Log tag.</param>
         /// <param name="message">Message.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Assert(string tag, string message)
         {
         }


### PR DESCRIPTION
I don't used `Obsolete` attribute to avoid lot of warnings inside SDK. Globally suppress obsolete warning is a bad idea.