### PR TITLE
WindowsClassic specific unit tests

### DIFF
--- a/MobileCenter-SDK-Test-Windows.sln
+++ b/MobileCenter-SDK-Test-Windows.sln
@@ -41,10 +41,19 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Mobile.Push
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Mobile.Test.UWP", "Tests\Microsoft.Azure.Mobile.Test.UWP\Microsoft.Azure.Mobile.Test.UWP.csproj", "{6D86EE4F-2871-4DC3-BCA4-A692DBEAE59D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Mobile.Test.WindowsClassic", "Tests\Microsoft.Azure.Mobile.Test.WindowsClassic\Microsoft.Azure.Mobile.Test.WindowsClassic.csproj", "{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Mobile.WindowsClassic", "SDK\MobileCenter\Microsoft.Azure.Mobile.WindowsClassic\Microsoft.Azure.Mobile.WindowsClassic.csproj", "{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Mobile.Analytics.WindowsClassic", "SDK\MobileCenterAnalytics\Microsoft.Azure.Mobile.Analytics.WindowsClassic\Microsoft.Azure.Mobile.Analytics.WindowsClassic.csproj", "{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		SDK\MobileCenter\Microsoft.Azure.Mobile.Shared\Microsoft.Azure.Mobile.Shared.projitems*{15e3fc9b-7714-4468-a296-81627a5b8f01}*SharedItemsImports = 4
 		SDK\MobileCenter\Microsoft.Azure.Mobile.Windows.Shared\Microsoft.Azure.Mobile.Windows.Shared.projitems*{15e3fc9b-7714-4468-a296-81627a5b8f01}*SharedItemsImports = 4
+		SDK\MobileCenter\Microsoft.Azure.Mobile.Shared\Microsoft.Azure.Mobile.Shared.projitems*{1e9ec0aa-3e32-4551-80c4-e4f3e53d7590}*SharedItemsImports = 4
+		SDK\MobileCenter\Microsoft.Azure.Mobile.Windows.Shared\Microsoft.Azure.Mobile.Windows.Shared.projitems*{1e9ec0aa-3e32-4551-80c4-e4f3e53d7590}*SharedItemsImports = 4
+		SDK\MobileCenterAnalytics\Microsoft.Azure.Mobile.Analytics.Windows.Shared\Microsoft.Azure.Mobile.Analytics.Windows.Shared.projitems*{1f6c139a-29bb-4e74-8df2-f8ccab399a67}*SharedItemsImports = 4
 		SDK\MobileCenterAnalytics\Microsoft.Azure.Mobile.Analytics.Windows.Shared\Microsoft.Azure.Mobile.Analytics.Windows.Shared.projitems*{200073bf-fa7e-42af-8ed5-aa50be7c0295}*SharedItemsImports = 4
 		SDK\MobileCenterAnalytics\Microsoft.Azure.Mobile.Analytics.Windows.Shared\Microsoft.Azure.Mobile.Analytics.Windows.Shared.projitems*{7ce5bf9e-3650-4151-8b54-c1301aa73606}*SharedItemsImports = 13
 		SDK\MobileCenterPush\Microsoft.Azure.Mobile.Push.Shared\Microsoft.Azure.Mobile.Push.Shared.projitems*{8072449c-c6a8-4b36-87dc-173f295d161c}*SharedItemsImports = 4
@@ -321,6 +330,78 @@ Global
 		{6D86EE4F-2871-4DC3-BCA4-A692DBEAE59D}.Release|x86.ActiveCfg = Release|x86
 		{6D86EE4F-2871-4DC3-BCA4-A692DBEAE59D}.Release|x86.Build.0 = Release|x86
 		{6D86EE4F-2871-4DC3-BCA4-A692DBEAE59D}.Release|x86.Deploy.0 = Release|x86
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|ARM.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x64.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x86.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Reference|Any CPU.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Reference|Any CPU.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Reference|ARM.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Reference|ARM.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Reference|x64.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Reference|x64.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Reference|x86.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Reference|x86.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|ARM.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|ARM.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x64.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x64.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x86.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x86.Build.0 = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Debug|ARM.Build.0 = Debug|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Debug|x64.Build.0 = Debug|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Debug|x86.Build.0 = Debug|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Reference|Any CPU.ActiveCfg = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Reference|Any CPU.Build.0 = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Reference|ARM.ActiveCfg = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Reference|ARM.Build.0 = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Reference|x64.ActiveCfg = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Reference|x64.Build.0 = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Reference|x86.ActiveCfg = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Reference|x86.Build.0 = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Release|ARM.ActiveCfg = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Release|ARM.Build.0 = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Release|x64.ActiveCfg = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Release|x64.Build.0 = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Release|x86.ActiveCfg = Release|Any CPU
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590}.Release|x86.Build.0 = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Debug|ARM.Build.0 = Debug|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Debug|x64.Build.0 = Debug|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Debug|x86.Build.0 = Debug|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Reference|Any CPU.ActiveCfg = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Reference|Any CPU.Build.0 = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Reference|ARM.ActiveCfg = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Reference|ARM.Build.0 = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Reference|x64.ActiveCfg = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Reference|x64.Build.0 = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Reference|x86.ActiveCfg = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Reference|x86.Build.0 = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Release|ARM.ActiveCfg = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Release|ARM.Build.0 = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Release|x64.ActiveCfg = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Release|x64.Build.0 = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Release|x86.ActiveCfg = Release|Any CPU
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -343,5 +424,8 @@ Global
 		{200073BF-FA7E-42AF-8ED5-AA50BE7C0295} = {7D1BE3C5-199E-483C-A62F-D0376346B0D7}
 		{8072449C-C6A8-4B36-87DC-173F295D161C} = {20870E0A-068E-4016-9B51-53B46696352B}
 		{6D86EE4F-2871-4DC3-BCA4-A692DBEAE59D} = {BC900C35-E0AD-46D2-BA4A-EF1904820B4A}
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6} = {BC900C35-E0AD-46D2-BA4A-EF1904820B4A}
+		{1E9EC0AA-3E32-4551-80C4-E4F3E53D7590} = {B699D34F-C961-4E03-89AD-6B00FF643AE8}
+		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67} = {7D1BE3C5-199E-483C-A62F-D0376346B0D7}
 	EndGlobalSection
 EndGlobal

--- a/MobileCenter-Windows.sln
+++ b/MobileCenter-Windows.sln
@@ -99,6 +99,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Mobile.Cras
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Contoso.WPF.Puppet", "Contoso.WPF.Puppet", "{97928097-15D5-4B88-8EF8-7E34E2604B65}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Mobile.Test.WindowsClassic", "Tests\Microsoft.Azure.Mobile.Test.WindowsClassic\Microsoft.Azure.Mobile.Test.WindowsClassic.csproj", "{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		SDK\MobileCenter\Microsoft.Azure.Mobile.Shared\Microsoft.Azure.Mobile.Shared.projitems*{15e3fc9b-7714-4468-a296-81627a5b8f01}*SharedItemsImports = 4
@@ -801,6 +803,30 @@ Global
 		{DC55C086-714D-4E2F-B6CE-3C14BC3B6646}.Release|x64.Build.0 = Release|Any CPU
 		{DC55C086-714D-4E2F-B6CE-3C14BC3B6646}.Release|x86.ActiveCfg = Release|Any CPU
 		{DC55C086-714D-4E2F-B6CE-3C14BC3B6646}.Release|x86.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|ARM.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x64.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x86.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|ARM.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|ARM.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|iPhone.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x64.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x64.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x86.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -851,5 +877,6 @@ Global
 		{1F6C139A-29BB-4E74-8DF2-F8CCAB399A67} = {95CACF52-25AA-4C05-B587-2BBF4B5514D1}
 		{DC55C086-714D-4E2F-B6CE-3C14BC3B6646} = {A60D537E-41F7-44D6-95C8-5DDB77B07308}
 		{97928097-15D5-4B88-8EF8-7E34E2604B65} = {AA6821F3-930A-49E4-BA3F-D68255F39F1E}
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6} = {BC900C35-E0AD-46D2-BA4A-EF1904820B4A}
 	EndGlobalSection
 EndGlobal

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationSettings.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationSettings.cs
@@ -4,19 +4,7 @@ namespace Microsoft.Azure.Mobile.Utils
 {
     public class ApplicationSettings : IApplicationSettings
     {
-        public object this[string key]
-        {
-            get
-            {
-                return ApplicationData.Current.LocalSettings.Values[key];
-            }
-            set
-            {
-                ApplicationData.Current.LocalSettings.Values[key] = value;
-            }
-        }
-
-        public T GetValue<T>(string key, T defaultValue)
+        public T GetValue<T>(string key, T defaultValue = default(T))
         {
             object result;
             var found = ApplicationData.Current.LocalSettings.Values.TryGetValue(key, out result);
@@ -24,8 +12,18 @@ namespace Microsoft.Azure.Mobile.Utils
             {
                 return (T)result;
             }
-            this[key] = defaultValue;
+            SetValue(key, defaultValue);
             return defaultValue;
+        }
+
+        public void SetValue(string key, object value)
+        {
+            ApplicationData.Current.LocalSettings.Values[key] = value;
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return ApplicationData.Current.LocalSettings.Values.ContainsKey(key);
         }
 
         public void Remove(string key)

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenter.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Mobile
                 }
 
                 _channelGroup?.SetEnabled(value);
-                _applicationSettings[EnabledKey] = value;
+                _applicationSettings.SetValue(EnabledKey, value);
 
                 foreach (var service in _services)
                 {

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterService.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterService.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Mobile
                         return;
                     }
                     Channel?.SetEnabled(value);
-                    _applicationSettings[EnabledPreferenceKey] = value;
+                    _applicationSettings.SetValue(EnabledPreferenceKey, value);
                     MobileCenterLog.Info(LogTag, $"{ServiceName} service has been {enabledString}");
                 }
             }
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Mobile
                 ChannelGroup = channelGroup;
                 Channel = channelGroup.AddChannel(ChannelName, TriggerCount, TriggerInterval, TriggerMaxParallelRequests);
                 var enabled = MobileCenter.Enabled && InstanceEnabled;
-                _applicationSettings[EnabledPreferenceKey] = enabled;
+                _applicationSettings.SetValue(EnabledPreferenceKey, enabled);
                 Channel.SetEnabled(enabled);
             }
         }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/IApplicationSettings.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/IApplicationSettings.cs
@@ -6,8 +6,9 @@
     public interface IApplicationSettings
     {
         // Returns the object corresponding to 'key'. If there is no such object, it creates one with the given default value, and returns that
-        T GetValue<T>(string key, T defaultValue);
+        T GetValue<T>(string key, T defaultValue = default(T));
+        void SetValue(string key, object value);
+        bool ContainsKey(string key);
         void Remove(string key);
-        object this[string key] { get; set; }
     }
 }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.WindowsClassic/MobileCenterPart.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.WindowsClassic/MobileCenterPart.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Azure.Mobile.Utils;
-
-namespace Microsoft.Azure.Mobile
+﻿namespace Microsoft.Azure.Mobile
 {
     public partial class MobileCenter
     {

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.WindowsClassic/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.WindowsClassic/Properties/AssemblyInfo.cs
@@ -35,3 +35,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("0.0.0.0")]
 [assembly: AssemblyFileVersion("0.12.1.0")]
 [assembly: AssemblyInformationalVersion("0.12.1-SNAPSHOT")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Mobile.Test.WindowsClassic")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.WindowsClassic/Utils/DeviceInformationHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.WindowsClassic/Utils/DeviceInformationHelper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Mobile.Utils
 
         protected override string GetAppNamespace()
         {
-             return Assembly.GetEntryAssembly().EntryPoint.DeclaringType.Namespace;
+             return Assembly.GetEntryAssembly()?.EntryPoint.DeclaringType?.Namespace;
         }
 
         protected override string GetDeviceOemName()

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Channel
             if (string.IsNullOrEmpty(sessionsString)) return;
             _sessions = SessionsFromString(sessionsString);
             // Re-write sessions in storage in case of any invalid strings
-            _applicationSettings[StorageKey] = SessionsAsString();
+            _applicationSettings.SetValue(StorageKey, SessionsAsString());
             if (_sessions.Count == 0) return;
             var loadedSessionsString = _sessions.Values.Aggregate("Loaded stored sessions:\n", (current, session) => current + ("\t" + session + "\n"));
             MobileCenterLog.Debug(Analytics.Instance.LogTag, loadedSessionsString);
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Channel
             }
             _sid = Guid.NewGuid();
             _sessions.Add(now, _sid.Value);
-            _applicationSettings[StorageKey] = SessionsAsString();
+            _applicationSettings.SetValue(StorageKey, SessionsAsString());
             var startSessionLog = new StartSessionLog { Sid = _sid };
             _channel.Enqueue(startSessionLog);
         }

--- a/Tests/Microsoft.Azure.Mobile.NET/ApplicationSettings.cs
+++ b/Tests/Microsoft.Azure.Mobile.NET/ApplicationSettings.cs
@@ -6,18 +6,11 @@ namespace Microsoft.Azure.Mobile.Utils
     /*
      * Application settings implemented in-memory with no persistence
      */
-
     [ExcludeFromCodeCoverage]
     public class ApplicationSettings : IApplicationSettings
     {
         private static readonly Dictionary<object, object> Settings = new Dictionary<object, object>();
-
-        public object this[string key]
-        {
-            get { return Settings[key]; }
-            set { Settings[key] = value; }
-        }
-
+        
         public T GetValue<T>(string key, T defaultValue)
         {
             object result;
@@ -26,8 +19,18 @@ namespace Microsoft.Azure.Mobile.Utils
             {
                 return (T) result;
             }
-            this[key] = defaultValue;
+            SetValue(key, defaultValue);
             return defaultValue;
+        }
+
+        public void SetValue(string key, object value)
+        {
+            Settings[key] = value;
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return Settings.ContainsKey(key);
         }
 
         public void Remove(string key)

--- a/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterServiceTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterServiceTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
             MobileCenter.Enabled = true;
             _testService.InstanceEnabled = false;
 
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = false, Times.Once());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, false), Times.Once());
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
 
             _testService.InstanceEnabled = true;
 
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = It.IsAny<bool>(), Times.Never());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, It.IsAny<bool>()), Times.Never());
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
 
             _testService.InstanceEnabled = true;
 
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = It.IsAny<bool>(), Times.Never());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, It.IsAny<bool>()), Times.Never());
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
 
             _testService.InstanceEnabled = false;
 
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = It.IsAny<bool>(), Times.Exactly(2));
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, It.IsAny<bool>()), Times.Exactly(2));
             _mockChannel.Verify(channel => channel.SetEnabled(It.IsAny<bool>()), Times.Exactly(2));
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
                 channelGroup =>
                     channelGroup.AddChannel(_testService.PublicChannelName, It.IsAny<int>(), It.IsAny<TimeSpan>(),
                         It.IsAny<int>()), Times.Once());
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = true, Times.Once());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, true), Times.Once());
             _mockChannel.Verify(channel => channel.SetEnabled(true), Times.Once());
             Assert.AreSame(_mockChannelGroup.Object, _testService.PublicChannelGroup);
         }
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
                 channelGroup =>
                     channelGroup.AddChannel(_testService.PublicChannelName, It.IsAny<int>(), It.IsAny<TimeSpan>(),
                         It.IsAny<int>()), Times.Once());
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = false, Times.Once());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, false), Times.Once());
             _mockChannel.Verify(channel => channel.SetEnabled(false), Times.Once());
         }
 

--- a/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterTest.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using Microsoft.Azure.Mobile.Channel;
+using Microsoft.Azure.Mobile.Ingestion.Models;
 using Microsoft.Azure.Mobile.Test.Windows.Channel;
 using Microsoft.Azure.Mobile.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.Azure.Mobile.Ingestion.Models;
 
 namespace Microsoft.Azure.Mobile.Test
 {
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Mobile.Test
 
             MockMobileCenterService.Instance.MockInstance.VerifySet(
                 service => service.InstanceEnabled = It.IsAny<bool>(), Times.Never());
-            settingsMock.VerifySet(settings => settings[MobileCenter.EnabledKey] = It.IsAny<bool>(), Times.Never());
+            settingsMock.Verify(settings => settings.SetValue(MobileCenter.EnabledKey, It.IsAny<bool>()), Times.Never());
             channelGroupMock.Verify(channelGroup => channelGroup.SetEnabled(It.IsAny<bool>()), Times.Never());
         }
 
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Mobile.Test
 
             MockMobileCenterService.Instance.MockInstance.VerifySet(service => service.InstanceEnabled = setVal,
                 Times.Once());
-            settingsMock.VerifySet(settings => settings[MobileCenter.EnabledKey] = setVal, Times.Once());
+            settingsMock.Verify(settings => settings.SetValue(MobileCenter.EnabledKey, setVal), Times.Once());
             channelGroupMock.Verify(channelGroup => channelGroup.SetEnabled(setVal), Times.Once());
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Mobile.Test
             MobileCenter.Enabled = false;
             MobileCenter.Start("appsecret", typeof(MockMobileCenterService));
 
-            settingsMock.VerifySet(settings => settings[MobileCenter.EnabledKey] = false, Times.Once());
+            settingsMock.Verify(settings => settings.SetValue(MobileCenter.EnabledKey, false), Times.Once());
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Mobile.Test
         {
             var settings = new ApplicationSettings();
             var fakeInstallId = Guid.NewGuid();
-            settings[MobileCenter.InstallIdKey] = fakeInstallId;
+            settings.SetValue(MobileCenter.InstallIdKey, fakeInstallId);
             MobileCenter.Instance = new MobileCenter(settings);
             var installId = MobileCenter.InstallId;
 

--- a/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Microsoft.Azure.Mobile.Test.WindowsClassic.csproj
+++ b/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Microsoft.Azure.Mobile.Test.WindowsClassic.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Azure.Mobile.Test.WindowsClassic</RootNamespace>
+    <AssemblyName>Microsoft.Azure.Mobile.Test.WindowsClassic</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.7.1.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MobileCenterTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\SDK\MobileCenter\Microsoft.Azure.Mobile.WindowsClassic\Microsoft.Azure.Mobile.WindowsClassic.csproj">
+      <Project>{1e9ec0aa-3e32-4551-80c4-e4f3e53d7590}</Project>
+      <Name>Microsoft.Azure.Mobile.WindowsClassic</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Microsoft.Azure.Mobile.Test.WindowsClassic.csproj
+++ b/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Microsoft.Azure.Mobile.Test.WindowsClassic.csproj
@@ -51,11 +51,12 @@
       <HintPath>..\..\packages\Moq.4.7.1\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MobileCenterTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils\ApplicationSettingsTest.cs" />
+    <Compile Include="Utils\DeviceInformationHelperTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/MobileCenterTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/MobileCenterTest.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Mobile.Test.WindowsClassic
+{
+    [TestClass]
+    public class MobileCenterTest
+    {
+        [TestInitialize]
+        public void InitializeMobileCenterTest()
+        {
+            MobileCenter.Instance = null;
+        }
+
+        /// <summary>
+        /// Verify configure with WindowsClassic platform id
+        /// </summary>
+        [TestMethod]
+        public void VerifyPlatformId()
+        {
+            MobileCenter.Configure("windowsclassicdesktop=appsecret");
+            Assert.IsTrue(MobileCenter.Configured);
+        }
+    }
+}

--- a/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Microsoft.Azure.Mobile.Test.WindowsClassic")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.Azure.Mobile.Test.WindowsClassic")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("c4674357-efba-43aa-9db8-de62a3309eb6")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Utils/ApplicationSettingsTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Utils/ApplicationSettingsTest.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Azure.Mobile.Utils;
+﻿using System.IO;
+using System.Reflection;
+using Microsoft.Azure.Mobile.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Windows.Storage;
 
-namespace Microsoft.Azure.Mobile.Test.UWP.Utils
+namespace Microsoft.Azure.Mobile.Test.WindowsClassic.Utils
 {
     [TestClass]
     public class ApplicationSettingsTest
@@ -12,7 +13,9 @@ namespace Microsoft.Azure.Mobile.Test.UWP.Utils
         [TestInitialize]
         public void InitializeMobileCenterTest()
         {
-            ApplicationData.Current.LocalSettings.Values.Clear();
+            var location = Assembly.GetExecutingAssembly().Location;
+            var path = Path.Combine(Path.GetDirectoryName(location), "MobileCenter.config");
+            File.Delete(path);
             settings = new ApplicationSettings();
         }
 

--- a/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Utils/DeviceInformationHelperTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/Utils/DeviceInformationHelperTest.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Azure.Mobile.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Mobile.Test.WindowsClassic.Utils
+{
+    [TestClass]
+    public class DeviceInformationHelperTest
+    {
+        /// <summary>
+        /// Verify sdk name in device information
+        /// </summary>
+        [TestMethod]
+        public void VerifySdkName()
+        {
+            var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
+            Assert.AreEqual(device.SdkName, "mobilecenter.winforms");
+        }
+    }
+}

--- a/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/packages.config
+++ b/Tests/Microsoft.Azure.Mobile.Test.WindowsClassic/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
+  <package id="Moq" version="4.7.1" targetFramework="net452" />
+  <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Also removed non-generic getter from application settings.
It's needed because on WindowsClassic we don't store info about value type and this never use in SDK.
For example, this code was fails before:
```
settings[key] = 42;
Assert.AreEqual(42, settings[key]); // "42"
```