### PR TITLE
Avoid duplicate start session when resuming with a log

### DIFF
--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Channel
             _sid = Guid.NewGuid();
             _sessions.Add(now, _sid.Value);
             _applicationSettings[StorageKey] = SessionsAsString();
+            _lastQueuedLogTime = TimeHelper.CurrentTimeInMilliseconds();
             var startSessionLog = new StartSessionLog { Sid = _sid };
             _channel.EnqueueAsync(startSessionLog);
         }

--- a/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/SessionTrackerTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/SessionTrackerTest.cs
@@ -55,6 +55,9 @@ namespace Microsoft.Azure.Mobile.Analytics.Test.Windows
             _mockChannel.Verify(channel => channel.EnqueueAsync(It.IsAny<StartSessionLog>()), Times.Exactly(2));
         }
 
+        /// <summary>
+        /// Verify that after a timeout, if we resume and send a log at the same time, only 1 new session is started
+        /// </summary>
         [TestMethod]
         public void ResumeAfterTimeoutAndSendEvent()
         {

--- a/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/SessionTrackerTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/SessionTrackerTest.cs
@@ -55,6 +55,20 @@ namespace Microsoft.Azure.Mobile.Analytics.Test.Windows
             _mockChannel.Verify(channel => channel.EnqueueAsync(It.IsAny<StartSessionLog>()), Times.Exactly(2));
         }
 
+        [TestMethod]
+        public void ResumeAfterTimeoutAndSendEvent()
+        {
+            _sessionTracker.Resume();
+            _sessionTracker.Pause();
+            Task.Delay((int)SessionTracker.SessionTimeout).Wait();
+            _mockChannel.Verify(channel => channel.EnqueueAsync(It.IsAny<StartSessionLog>()), Times.Once());
+
+            _sessionTracker.Resume();
+            _mockChannelGroup.Raise(group => group.EnqueuingLog += null, null, new EnqueuingLogEventArgs(new EventLog()));
+
+            _mockChannel.Verify(channel => channel.EnqueueAsync(It.IsAny<StartSessionLog>()), Times.Exactly(2));
+        }
+
         /// <summary>
         /// Verify that after a pause that is not long enough to be a timeout, the session tracker does not send a start session log
         /// </summary>


### PR DESCRIPTION
Same as https://github.com/Microsoft/mobile-center-sdk-android/pull/456