### PR TITLE
Fix null parameter handling

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/MobileCenter.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Mobile
             {
                 parsedSecret = GetSecretForPlatform(appSecret, PlatformIdentifier);
             }
-            catch (ArgumentException ex)
+            catch (MobileCenterException ex)
             {
                 MobileCenterLog.Assert(MobileCenterLog.LogTag, ex.Message);
                 return;

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/ApiDefinition.cs
@@ -131,23 +131,23 @@ namespace Microsoft.Azure.Mobile.iOS.Bindings
     {
         // - (instancetype)setString:(NSString *)value forKey:(NSString *)key;
         [Export("setString:forKey:")]
-        void Set(string value, string key);
+        void Set([NullAllowed] string value, [NullAllowed] string key);
 
         // - (instancetype)setNumber:(NSNumber *)value forKey:(NSString *)key;
         [Export("setNumber:forKey:")]
-        void Set(NSNumber value, string key);
+        void Set(NSNumber value, [NullAllowed] string key);
 
         // - (instancetype)setBool:(BOOL)value forKey:(NSString *)key;
         [Export("setBool:forKey:")]
-        void Set(bool value, string key);
+        void Set(bool value, [NullAllowed] string key);
 
         // - (instancetype)setDate:(NSDate *)value forKey:(NSString *)key;
         [Export("setDate:forKey:")]
-        void Set(NSDate value, string key);
+        void Set(NSDate value, [NullAllowed] string key);
 
         // - (instancetype)clearPropertyForKey:(NSString *)key;
         [Export("clearPropertyForKey:")]
-        void Clear(string key);
+        void Clear([NullAllowed] string key);
     }
 
     // @interface MSMobileCenter : NSObject

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/ApiDefinition.cs
@@ -162,12 +162,12 @@ namespace Microsoft.Azure.Mobile.iOS.Bindings
         // +(void)configureWithAppSecret:(NSString *)appSecret;
         [Static]
         [Export("configureWithAppSecret:")]
-        void ConfigureWithAppSecret(string appSecret);
+        void ConfigureWithAppSecret([NullAllowed] string appSecret);
 
         // +(void)start:(NSString *)appSecret withServices:(NSArray<Class> *)services;
         [Static]
         [Export("start:withServices:")]
-        void Start(string appSecret, Class[] services);
+        void Start([NullAllowed] string appSecret, Class[] services);
 
         // +(void)startService:(Class)service;
         [Static]
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Mobile.iOS.Bindings
         // +(void)setLogUrl:(NSString *)setLogUrl;
         [Static]
         [Export("setLogUrl:")]
-        void SetLogUrl(string logUrl);
+        void SetLogUrl([NullAllowed] string logUrl);
 
         // +(void)setEnabled:(BOOL)isEnabled;
         [Static]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/ApiDefinition.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Mobile.iOS.Bindings
         // + (void)setCustomProperties:(MSCustomProperties *)customProperties;
         [Static]
         [Export("setCustomProperties:")]
-        void SetCustomProperties(MSCustomProperties properties);
+        void SetCustomProperties([NullAllowed] MSCustomProperties properties);
     }
 
     // @protocol MSService <NSObject>

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/MobileCenter.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Mobile
 
         static void PlatformSetCustomProperties(CustomProperties customProperties)
         {
-            iOSMobileCenter.SetCustomProperties(customProperties.IOSCustomProperties);
+            iOSMobileCenter.SetCustomProperties(customProperties?.IOSCustomProperties);
         }
     }
 }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/MobileCenter.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Mobile
             {
                 parsedSecret = GetSecretForPlatform(appSecret, PlatformIdentifier);
             }
-            catch (ArgumentException ex)
+            catch (MobileCenterException ex)
             {
                 MobileCenterLog.Assert(MobileCenterLog.LogTag, ex.Message);
                 return;

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS.Bindings/ApiDefinition.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Mobile.Analytics.iOS.Bindings
         // +(void)trackEvent:(NSString *)eventName withProperties:(NSDictionary *)properties;
         [Static]
         [Export("trackEvent:withProperties:")]
-        void TrackEvent(string eventName, NSDictionary properties);
+        void TrackEvent(string eventName, [NullAllowed] NSDictionary properties);
 
         // +(void)setDelegate:(id<MSAnalyticsDelegate> _Nullable)delegate;
         [Static]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS.Bindings/ApiDefinition.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Azure.Mobile.Analytics.iOS.Bindings
         // +(void)trackEvent:(NSString *)eventName;
         [Static]
         [Export("trackEvent:")]
-        void TrackEvent(string eventName);
+        void TrackEvent([NullAllowed] string eventName);
 
         // +(void)trackEvent:(NSString *)eventName withProperties:(NSDictionary *)properties;
         [Static]
         [Export("trackEvent:withProperties:")]
-        void TrackEvent(string eventName, [NullAllowed] NSDictionary properties);
+        void TrackEvent([NullAllowed] string eventName, [NullAllowed] NSDictionary properties);
 
         // +(void)setDelegate:(id<MSAnalyticsDelegate> _Nullable)delegate;
         [Static]


### PR DESCRIPTION
It was crashing instead of logging an error from native SDK.