### PR TITLE
Compatible with non XAML applications

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationLifecycleHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationLifecycleHelper.cs
@@ -51,14 +51,14 @@ namespace Microsoft.Azure.Mobile.Utils
             {
                 try
                 {
-                    // intentionally propagating exception to get the exception object that crashed the app.
+                    // Intentionally propagating exception to get the exception object that crashed the app.
                     eventArgs.UnhandledError.Propagate();
                 }
                 catch (Exception exception)
                 {
                     UnhandledExceptionOccurred?.Invoke(sender, new UnhandledExceptionOccurredEventArgs(exception));
 
-                    // If we don't throw exception - app will not be crashed. We need to throw to not change the app behavior.
+                    // Since UnhandledError.Propagate marks the error as Handled, rethrow in order to only Log and not Handle.
                     throw;
                 }
             };

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationLifecycleHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationLifecycleHelper.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using Windows.ApplicationModel.Core;
 using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
-using System.Linq;
-using System.Threading.Tasks;
-using Windows.UI.Core;
 
 namespace Microsoft.Azure.Mobile.Utils
 {
@@ -51,10 +46,17 @@ namespace Microsoft.Azure.Mobile.Utils
                 // the start
                 _started = true;
             }
-            Application.Current.UnhandledException += (sender, eventArgs) =>
+            try
             {
-                UnhandledExceptionOccurred?.Invoke(sender, new UnhandledExceptionOccurredEventArgs(eventArgs.Exception));
-            };
+                Application.Current.UnhandledException += (sender, eventArgs) =>
+                {
+                    UnhandledExceptionOccurred?.Invoke(sender, new UnhandledExceptionOccurredEventArgs(eventArgs.Exception));
+                };
+            }
+            catch (Exception exception)
+            {
+                MobileCenterLog.Warn(MobileCenterLog.LogTag, "Cannot subscribe to unhandled exceptions from XAML application", exception);
+            }
         }
 
         private void InvokeResuming(object sender, object e)

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationLifecycleHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationLifecycleHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Windows.ApplicationModel.Core;
 using Windows.Foundation.Metadata;
-using Windows.UI.Xaml;
 
 namespace Microsoft.Azure.Mobile.Utils
 {
@@ -46,17 +45,23 @@ namespace Microsoft.Azure.Mobile.Utils
                 // the start
                 _started = true;
             }
-            try
+
+            // Subscribe to unhandled errors events
+            CoreApplication.UnhandledErrorDetected += (sender, eventArgs) =>
             {
-                Application.Current.UnhandledException += (sender, eventArgs) =>
+                try
                 {
-                    UnhandledExceptionOccurred?.Invoke(sender, new UnhandledExceptionOccurredEventArgs(eventArgs.Exception));
-                };
-            }
-            catch (Exception exception)
-            {
-                MobileCenterLog.Warn(MobileCenterLog.LogTag, "Cannot subscribe to unhandled exceptions from XAML application", exception);
-            }
+                    // intentionally propagating exception to get the exception object that crashed the app.
+                    eventArgs.UnhandledError.Propagate();
+                }
+                catch (Exception exception)
+                {
+                    UnhandledExceptionOccurred?.Invoke(sender, new UnhandledExceptionOccurredEventArgs(exception));
+
+                    // If we don't throw exception - app will not be crashed. We need to throw to not change the app behavior.
+                    throw;
+                }
+            };
         }
 
         private void InvokeResuming(object sender, object e)

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DeviceInformationHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DeviceInformationHelper.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.ApplicationModel;
 using Windows.System.Profile;
 using Windows.Security.ExchangeActiveSyncProvisioning;
 using Windows.ApplicationModel.Core;
 using Windows.Foundation.Metadata;
 using Windows.Graphics.Display;
-using Windows.UI.Xaml;
 
 namespace Microsoft.Azure.Mobile.Utils
 {
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Mobile.Utils
 
         protected override string GetAppNamespace()
         {
-            return Application.Current.GetType().Namespace;
+            return Package.Current.Id.Name;
         }
 
         protected override string GetDeviceOemName()
@@ -102,13 +102,13 @@ namespace Microsoft.Azure.Mobile.Utils
 
         protected override string GetAppVersion()
         {
-            var packageVersion = Windows.ApplicationModel.Package.Current.Id.Version;
+            var packageVersion = Package.Current.Id.Version;
             return $"{packageVersion.Major}.{packageVersion.Minor}.{packageVersion.Build}.{packageVersion.Revision}";
         }
 
         protected override string GetAppBuild()
         {
-            var packageVersion = Windows.ApplicationModel.Package.Current.Id.Version;
+            var packageVersion = Package.Current.Id.Version;
             return $"{packageVersion.Major}.{packageVersion.Minor}.{packageVersion.Build}.{packageVersion.Revision}";
         }
 


### PR DESCRIPTION
Used `Package.Current.Id.Name` instead of `Application.Current.GetType().Namespace` in `GetAppNamespace()` to not use `Windows.UI.Xaml.Application.Current` and be compatible with non XAML applications.
`app_namespace` description:
> The bundle identifier, package identifier, or namespace, depending on what the individual platforms use,  .e.g com.microsoft.example.

Also subscription to XAML unhandled exceptions wrapped into `try`/`catch` block to avoid fail on non XAML applications.