### PR TITLE
Use warning log level when truncating event name

### DIFF
--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Analytics.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Analytics.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Mobile.Analytics
             }
             if (name.Length > MaxEventNameLength)
             {
-                MobileCenterLog.Error(LogTag,
+                MobileCenterLog.Warn(LogTag,
                     $"{logType} '{name}' : name length cannot be longer than {MaxEventNameLength} characters. Name will be truncated.");
                 name = name.Substring(0, MaxEventNameLength);
                 return true;


### PR DESCRIPTION
Target to [this comment](https://github.com/Microsoft/mobile-center-sdk-dotnet/pull/391#discussion_r132073036)