### PR TITLE
Change behavior of SessionTracker to start in 'suspended' state

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationLifecycleHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/ApplicationLifecycleHelper.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Azure.Mobile.Utils
     public class ApplicationLifecycleHelper : IApplicationLifecycleHelper
     {
         private static bool _started;
-        private static bool _suspended;
+        
+        // Considered to be suspended until can verify that has started
+        private static bool _suspended = true;
 
         // Singleton instance of ApplicationLifecycleHelper
         private static ApplicationLifecycleHelper _instance;

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Analytics.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Analytics.cs
@@ -163,11 +163,11 @@ namespace Microsoft.Azure.Mobile.Analytics
                 if (enabled && ChannelGroup != null && SessionTracker == null)
                 {
                     SessionTracker = CreateSessionTracker(ChannelGroup, Channel);
-                    SubscribeToApplicationLifecycleEvents();
                     if (!ApplicationLifecycleHelper.Instance.IsSuspended)
                     {
                         SessionTracker.Resume();
                     }
+                    SubscribeToApplicationLifecycleEvents();
                 }
                 else if (!enabled)
                 {

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Channel
                 return;
             }
             _sessions = SessionsFromString(sessionsString);
+
             // Re-write sessions in storage in case of any invalid strings
             _applicationSettings[StorageKey] = SessionsAsString();
             if (_sessions.Count == 0)


### PR DESCRIPTION
Fix a warning log by making SessionTracker "suspended" until it can be verified that it is not suspended.