### PR TITLE
Make possible to use custom application settings

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Microsoft.Azure.Mobile.UWP.csproj
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Microsoft.Azure.Mobile.UWP.csproj
@@ -163,7 +163,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\ScreenSizeProviderBase.cs" />
     <Compile Include="Utils\ApplicationLifecycleHelper.cs" />
-    <Compile Include="Utils\ApplicationSettings.cs" />
+    <Compile Include="Utils\DefaultApplicationSettings.cs" />
     <Compile Include="Utils\DefaultScreenSizeProvider.cs" />
     <Compile Include="Utils\DeviceInformationHelper.cs" />
     <Compile Include="Utils\DefaultScreenSizeProviderFactory.cs" />

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DefaultApplicationSettings.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DefaultApplicationSettings.cs
@@ -4,19 +4,7 @@ namespace Microsoft.Azure.Mobile.Utils
 {
     public class DefaultApplicationSettings : IApplicationSettings
     {
-        public object this[string key]
-        {
-            get
-            {
-                return ApplicationData.Current.LocalSettings.Values[key];
-            }
-            set
-            {
-                ApplicationData.Current.LocalSettings.Values[key] = value;
-            }
-        }
-
-        public T GetValue<T>(string key, T defaultValue)
+        public T GetValue<T>(string key, T defaultValue = default(T))
         {
             object result;
             var found = ApplicationData.Current.LocalSettings.Values.TryGetValue(key, out result);
@@ -24,8 +12,18 @@ namespace Microsoft.Azure.Mobile.Utils
             {
                 return (T)result;
             }
-            this[key] = defaultValue;
+            SetValue(key, defaultValue);
             return defaultValue;
+        }
+
+        public void SetValue(string key, object value)
+        {
+            ApplicationData.Current.LocalSettings.Values[key] = value;
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return ApplicationData.Current.LocalSettings.Values.ContainsKey(key);
         }
 
         public void Remove(string key)

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DefaultApplicationSettings.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DefaultApplicationSettings.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Azure.Mobile.Utils
 {
-    public class ApplicationSettings : IApplicationSettings
+    public class DefaultApplicationSettings : IApplicationSettings
     {
         public object this[string key]
         {

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DefaultScreenSizeProvider.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DefaultScreenSizeProvider.cs
@@ -6,7 +6,7 @@ using Windows.Graphics.Display;
 
 namespace Microsoft.Azure.Mobile.Utils
 {
-    class DefaultScreenSizeProvider : ScreenSizeProviderBase
+    public class DefaultScreenSizeProvider : ScreenSizeProviderBase
     {
         private readonly SemaphoreSlim _displayInformationEventSemaphore = new SemaphoreSlim(0);
         private readonly object _lockObject = new object();

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DeviceInformationHelper.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Utils/DeviceInformationHelper.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 using Windows.System.Profile;
 using Windows.Security.ExchangeActiveSyncProvisioning;
-using Windows.ApplicationModel.Core;
-using Windows.Foundation.Metadata;
-using Windows.Graphics.Display;
 
 namespace Microsoft.Azure.Mobile.Utils
 {

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Microsoft.Azure.Mobile.Windows.Shared.projitems
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Microsoft.Azure.Mobile.Windows.Shared.projitems
@@ -56,8 +56,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Storage\Storage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Storage\StorageException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\AbstractDeviceInformationHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\DefaultApplicationSettingsFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IApplicationLifecycleHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IApplicationSettings.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\IApplicationSettingsFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IDeviceInformationHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\Synchronization\State.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\Synchronization\StatefulMutex.cs" />

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 using Microsoft.Azure.Mobile.Channel;
 using Microsoft.Azure.Mobile.Ingestion.Models;
@@ -25,6 +26,7 @@ namespace Microsoft.Azure.Mobile
         // The lock is static. Instance methods are not necessarily thread safe, but static methods are
         private static readonly object MobileCenterLock = new object();
 
+        private static IApplicationSettingsFactory _applicationSettingsFactory = new DefaultApplicationSettingsFactory();
         private readonly IApplicationSettings _applicationSettings;
         private readonly IChannelGroupFactory _channelGroupFactory;
         private IChannelGroup _channelGroup;
@@ -77,6 +79,15 @@ namespace Microsoft.Azure.Mobile
                     MobileCenterLog.Level = value;
                 }
             }
+        }
+
+        // This method must be called *before* instance of MobileCenter has been created
+        // for a custom application settings to be used.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete]
+        public static void SetApplicationSettingsFactory(IApplicationSettingsFactory factory)
+        {
+            _applicationSettingsFactory = factory;
         }
 
         static Task<bool> PlatformIsEnabledAsync()
@@ -175,7 +186,7 @@ namespace Microsoft.Azure.Mobile
         // Creates a new instance of MobileCenter
         private MobileCenter()
         {
-            _applicationSettings = new ApplicationSettings();
+            _applicationSettings = _applicationSettingsFactory.CreateApplicationSettings();
             LogSerializer.AddLogType(StartServiceLog.JsonIdentifier, typeof(StartServiceLog));
             LogSerializer.AddLogType(CustomPropertiesLog.JsonIdentifier, typeof(CustomPropertiesLog));
         }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenter.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Mobile
                 }
 
                 _channelGroup?.SetEnabled(value);
-                _applicationSettings[EnabledKey] = value;
+                _applicationSettings.SetValue(EnabledKey, value);
 
                 foreach (var service in _services)
                 {

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenter.cs
@@ -198,6 +198,11 @@ namespace Microsoft.Azure.Mobile
             _channelGroupFactory = channelGroupFactory;
         }
 
+        internal IApplicationSettings ApplicationSettings
+        {
+            get { return _applicationSettings; }
+        }
+
         private bool InstanceEnabled
         {
             get

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterService.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Mobile
         private const string PreferenceKeySeparator = "_";
         private const string KeyEnabled = Constants.KeyPrefix + "ServiceEnabled";
         protected readonly object _serviceLock = new object();
-        private readonly IApplicationSettings _applicationSettings = new ApplicationSettings();
+        private readonly IApplicationSettings _applicationSettings = new DefaultApplicationSettings();
 
         /// <summary>
         /// Channel associated with this service. Should be disposed only by ChannelGroup.

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterService.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterService.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Azure.Mobile
         private const string PreferenceKeySeparator = "_";
         private const string KeyEnabled = Constants.KeyPrefix + "ServiceEnabled";
         protected readonly object _serviceLock = new object();
-        private readonly IApplicationSettings _applicationSettings = new DefaultApplicationSettings();
+
+        /// <summary>
+        /// Application settings.
+        /// </summary>
+        protected virtual IApplicationSettings ApplicationSettings => MobileCenter.Instance.ApplicationSettings;
 
         /// <summary>
         /// Channel associated with this service. Should be disposed only by ChannelGroup.
@@ -59,16 +63,6 @@ namespace Microsoft.Azure.Mobile
         /// </summary>
         protected virtual int TriggerMaxParallelRequests => Constants.DefaultTriggerMaxParallelRequests;
 
-        protected MobileCenterService()
-        {
-        }
-
-        // This constructor is only for testing
-        internal MobileCenterService(IApplicationSettings settings)
-        {
-            _applicationSettings = settings;
-        }
-
         /// <summary>
         /// Gets or sets whether service is enabled
         /// </summary>
@@ -78,7 +72,7 @@ namespace Microsoft.Azure.Mobile
             {
                 lock (_serviceLock)
                 {
-                    return _applicationSettings.GetValue(EnabledPreferenceKey, true);
+                    return ApplicationSettings.GetValue(EnabledPreferenceKey, true);
                 }
             }
             set
@@ -98,7 +92,7 @@ namespace Microsoft.Azure.Mobile
                         return;
                     }
                     Channel?.SetEnabled(value);
-                    _applicationSettings[EnabledPreferenceKey] = value;
+                    ApplicationSettings[EnabledPreferenceKey] = value;
                     MobileCenterLog.Info(LogTag, $"{ServiceName} service has been {enabledString}");
                 }
             }
@@ -117,7 +111,7 @@ namespace Microsoft.Azure.Mobile
                 ChannelGroup = channelGroup;
                 Channel = channelGroup.AddChannel(ChannelName, TriggerCount, TriggerInterval, TriggerMaxParallelRequests);
                 var enabled = MobileCenter.IsEnabledAsync().Result && InstanceEnabled;
-                _applicationSettings[EnabledPreferenceKey] = enabled;
+                ApplicationSettings[EnabledPreferenceKey] = enabled;
                 Channel.SetEnabled(enabled);
             }
         }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterService.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/MobileCenterService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Mobile
                         return;
                     }
                     Channel?.SetEnabled(value);
-                    ApplicationSettings[EnabledPreferenceKey] = value;
+                    ApplicationSettings.SetValue(EnabledPreferenceKey, value);
                     MobileCenterLog.Info(LogTag, $"{ServiceName} service has been {enabledString}");
                 }
             }
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Mobile
                 ChannelGroup = channelGroup;
                 Channel = channelGroup.AddChannel(ChannelName, TriggerCount, TriggerInterval, TriggerMaxParallelRequests);
                 var enabled = MobileCenter.IsEnabledAsync().Result && InstanceEnabled;
-                ApplicationSettings[EnabledPreferenceKey] = enabled;
+                ApplicationSettings.SetValue(EnabledPreferenceKey, enabled);
                 Channel.SetEnabled(enabled);
             }
         }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/DefaultApplicationSettingsFactory.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/DefaultApplicationSettingsFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Azure.Mobile.Utils
+{
+    public class DefaultApplicationSettingsFactory : IApplicationSettingsFactory
+    {
+        public IApplicationSettings CreateApplicationSettings()
+        {
+            return new DefaultApplicationSettings();
+        }
+    }
+}

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/IApplicationSettings.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/IApplicationSettings.cs
@@ -6,8 +6,9 @@
     public interface IApplicationSettings
     {
         // Returns the object corresponding to 'key'. If there is no such object, it creates one with the given default value, and returns that
-        T GetValue<T>(string key, T defaultValue);
+        T GetValue<T>(string key, T defaultValue = default(T));
+        void SetValue(string key, object value);
+        bool ContainsKey(string key);
         void Remove(string key);
-        object this[string key] { get; set; }
     }
 }

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/IApplicationSettingsFactory.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Windows.Shared/Utils/IApplicationSettingsFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Azure.Mobile.Utils
+{
+    public interface IApplicationSettingsFactory
+    {
+        IApplicationSettings CreateApplicationSettings();
+    }
+}

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Channel
         private long _lastQueuedLogTime;
         private long _lastResumedTime;
         private long _lastPausedTime;
-        private readonly ApplicationSettings _applicationSettings = new ApplicationSettings();
+        private readonly DefaultApplicationSettings _applicationSettings = new DefaultApplicationSettings();
         private readonly object _lockObject = new object();
 
         // This field is purely for testing

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Windows.Shared/Channel/SessionTracker.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Channel
             }
             _sessions = SessionsFromString(sessionsString);
             // Re-write sessions in storage in case of any invalid strings
-            _applicationSettings[StorageKey] = SessionsAsString();
+            _applicationSettings.SetValue(StorageKey, SessionsAsString());
             if (_sessions.Count == 0)
             {
                 return;
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Channel
             }
             _sid = Guid.NewGuid();
             _sessions.Add(now, _sid.Value);
-            _applicationSettings[StorageKey] = SessionsAsString();
+            _applicationSettings.SetValue(StorageKey, SessionsAsString());
             _lastQueuedLogTime = TimeHelper.CurrentTimeInMilliseconds();
             var startSessionLog = new StartSessionLog { Sid = _sid };
             _channel.EnqueueAsync(startSessionLog);

--- a/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/SessionTrackerTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/SessionTrackerTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Test.Windows
             _mockChannelGroup.Setup(
                     group => group.AddChannel(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TimeSpan>(), It.IsAny<int>()))
                 .Returns(_mockChannel.Object);
-            ApplicationSettings.Reset();
+            DefaultApplicationSettings.Reset();
             _sessionTracker = new SessionTracker(_mockChannelGroup.Object, _mockChannel.Object);
             SessionTracker.SessionTimeout = 500;
         }
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Mobile.Analytics.Test.Windows
             _sessionTracker.Resume();
             _sessionTracker.ClearSessions();
 
-            Assert.IsTrue(ApplicationSettings.IsEmpty);
+            Assert.IsTrue(DefaultApplicationSettings.IsEmpty);
         }
 
         /// <summary>

--- a/Tests/Microsoft.Azure.Mobile.NET/DefaultApplicationSettings.cs
+++ b/Tests/Microsoft.Azure.Mobile.NET/DefaultApplicationSettings.cs
@@ -3,12 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Azure.Mobile.Utils
 {
-    /*
-     * Application settings implemented in-memory with no persistence
-     */
-
+    /// <summary>
+    /// Application settings implemented in-memory with no persistence.
+    /// </summary>
     [ExcludeFromCodeCoverage]
-    public class ApplicationSettings : IApplicationSettings
+    public class DefaultApplicationSettings : IApplicationSettings
     {
         private static readonly Dictionary<object, object> Settings = new Dictionary<object, object>();
 

--- a/Tests/Microsoft.Azure.Mobile.NET/DefaultApplicationSettings.cs
+++ b/Tests/Microsoft.Azure.Mobile.NET/DefaultApplicationSettings.cs
@@ -10,13 +10,7 @@ namespace Microsoft.Azure.Mobile.Utils
     public class DefaultApplicationSettings : IApplicationSettings
     {
         private static readonly Dictionary<object, object> Settings = new Dictionary<object, object>();
-
-        public object this[string key]
-        {
-            get { return Settings[key]; }
-            set { Settings[key] = value; }
-        }
-
+        
         public T GetValue<T>(string key, T defaultValue)
         {
             object result;
@@ -25,8 +19,17 @@ namespace Microsoft.Azure.Mobile.Utils
             {
                 return (T) result;
             }
-            this[key] = defaultValue;
+            SetValue(key, defaultValue);
             return defaultValue;
+        }
+        public void SetValue(string key, object value)
+        {
+            Settings[key] = value;
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return Settings.ContainsKey(key);
         }
 
         public void Remove(string key)

--- a/Tests/Microsoft.Azure.Mobile.NET/Microsoft.Azure.Mobile.NET.csproj
+++ b/Tests/Microsoft.Azure.Mobile.NET/Microsoft.Azure.Mobile.NET.csproj
@@ -84,7 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationLifecycleHelper.cs" />
-    <Compile Include="ApplicationSettings.cs" />
+    <Compile Include="DefaultApplicationSettings.cs" />
     <Compile Include="DeviceInformationHelper.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="MobileCenterPart.cs" />

--- a/Tests/Microsoft.Azure.Mobile.Test.UWP/Utils/ApplicationSettingsTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.UWP/Utils/ApplicationSettingsTest.cs
@@ -7,38 +7,39 @@ namespace Microsoft.Azure.Mobile.Test.UWP.Utils
     [TestClass]
     public class ApplicationSettingsTest
     {
-        private readonly IApplicationSettings settings = new DefaultApplicationSettings();
+        private IApplicationSettings settings;
 
         [TestInitialize]
         public void InitializeMobileCenterTest()
         {
             ApplicationData.Current.LocalSettings.Values.Clear();
+            settings = new DefaultApplicationSettings();
         }
 
         /// <summary>
-        /// Verify access to values
+        /// Verify SetValue generic method behaviour
         /// </summary>
         [TestMethod]
-        public void VerifyAccess()
+        public void VerifySetValue()
         {
             const string key = "test";
-            Assert.AreEqual(null, settings[key]);
-            settings[key] = "test";
-            Assert.AreEqual("test", settings[key]);
-            settings[key] = 42;
-            Assert.AreEqual(42, settings[key]);
+            Assert.IsFalse(settings.ContainsKey(key));
+            settings.SetValue(key, 42);
+            Assert.IsTrue(settings.ContainsKey(key));
+            Assert.AreEqual(42, settings.GetValue<int>(key));
         }
 
         /// <summary>
-        /// Verify GetValue generic method behaviour
+        /// Verify GetValue and SetValue generic method behaviour
         /// </summary>
         [TestMethod]
         public void VerifyGetValue()
         {
             const string key = "test";
-            Assert.AreEqual(null, settings[key]);
+            Assert.IsFalse(settings.ContainsKey(key));
             Assert.AreEqual(42, settings.GetValue(key, 42));
-            Assert.AreEqual(42, settings[key]);
+            Assert.IsTrue(settings.ContainsKey(key));
+            Assert.AreEqual(42, settings.GetValue<int>(key));
             Assert.AreEqual(42, settings.GetValue(key, 0));
         }
 
@@ -48,12 +49,13 @@ namespace Microsoft.Azure.Mobile.Test.UWP.Utils
         [TestMethod]
         public void VerifyRemove()
         {
-            const string key = "test";
-            Assert.AreEqual(null, settings[key]);
-            settings[key] = 42;
-            Assert.AreEqual(42, settings[key]);
+            const string key = "test"; Assert.IsFalse(settings.ContainsKey(key));
+            settings.SetValue(key, 42);
+            Assert.IsTrue(settings.ContainsKey(key));
+            Assert.AreEqual(42, settings.GetValue<int>(key));
             settings.Remove(key);
-            Assert.AreEqual(null, settings[key]);
+            Assert.IsFalse(settings.ContainsKey(key));
+
         }
     }
 }

--- a/Tests/Microsoft.Azure.Mobile.Test.UWP/Utils/ApplicationSettingsTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.UWP/Utils/ApplicationSettingsTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Mobile.Test.UWP.Utils
     [TestClass]
     public class ApplicationSettingsTest
     {
-        private readonly IApplicationSettings settings = new ApplicationSettings();
+        private readonly IApplicationSettings settings = new DefaultApplicationSettings();
 
         [TestInitialize]
         public void InitializeMobileCenterTest()

--- a/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterServiceTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterServiceTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
             MobileCenter.SetEnabledAsync(true).Wait();
             _testService.InstanceEnabled = false;
 
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = false, Times.Once());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, false), Times.Once());
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
 
             _testService.InstanceEnabled = true;
 
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = It.IsAny<bool>(), Times.Never());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, It.IsAny<bool>()), Times.Never());
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
 
             _testService.InstanceEnabled = true;
 
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = It.IsAny<bool>(), Times.Never());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, It.IsAny<bool>()), Times.Never());
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
 
             _testService.InstanceEnabled = false;
 
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = It.IsAny<bool>(), Times.Exactly(2));
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, It.IsAny<bool>()), Times.Exactly(2));
             _mockChannel.Verify(channel => channel.SetEnabled(It.IsAny<bool>()), Times.Exactly(2));
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
                 channelGroup =>
                     channelGroup.AddChannel(_testService.PublicChannelName, It.IsAny<int>(), It.IsAny<TimeSpan>(),
                         It.IsAny<int>()), Times.Once());
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = true, Times.Once());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, true), Times.Once());
             _mockChannel.Verify(channel => channel.SetEnabled(true), Times.Once());
             Assert.AreSame(_mockChannelGroup.Object, _testService.PublicChannelGroup);
         }
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Mobile.Test.Windows
                 channelGroup =>
                     channelGroup.AddChannel(_testService.PublicChannelName, It.IsAny<int>(), It.IsAny<TimeSpan>(),
                         It.IsAny<int>()), Times.Once());
-            _mockSettings.VerifySet(settings => settings[_testService.PublicEnabledPreferenceKey] = false, Times.Once());
+            _mockSettings.Verify(settings => settings.SetValue(_testService.PublicEnabledPreferenceKey, false), Times.Once());
             _mockChannel.Verify(channel => channel.SetEnabled(false), Times.Once());
         }
 

--- a/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterTest.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using Microsoft.Azure.Mobile.Channel;
+using Microsoft.Azure.Mobile.Ingestion.Models;
 using Microsoft.Azure.Mobile.Test.Windows.Channel;
 using Microsoft.Azure.Mobile.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.Azure.Mobile.Ingestion.Models;
 
 namespace Microsoft.Azure.Mobile.Test
 {
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Mobile.Test
 
             MockMobileCenterService.Instance.MockInstance.VerifySet(
                 service => service.InstanceEnabled = It.IsAny<bool>(), Times.Never());
-            settingsMock.VerifySet(settings => settings[MobileCenter.EnabledKey] = It.IsAny<bool>(), Times.Never());
+            settingsMock.Verify(settings => settings.SetValue(MobileCenter.EnabledKey, It.IsAny<bool>()), Times.Never());
             channelGroupMock.Verify(channelGroup => channelGroup.SetEnabled(It.IsAny<bool>()), Times.Never());
         }
 
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Mobile.Test
 
             MockMobileCenterService.Instance.MockInstance.VerifySet(service => service.InstanceEnabled = setVal,
                 Times.Once());
-            settingsMock.VerifySet(settings => settings[MobileCenter.EnabledKey] = setVal, Times.Once());
+            settingsMock.Verify(settings => settings.SetValue(MobileCenter.EnabledKey, setVal), Times.Once());
             channelGroupMock.Verify(channelGroup => channelGroup.SetEnabled(setVal), Times.Once());
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Mobile.Test
             MobileCenter.SetEnabledAsync(false).Wait();
             MobileCenter.Start("appsecret", typeof(MockMobileCenterService));
 
-            settingsMock.VerifySet(settings => settings[MobileCenter.EnabledKey] = false, Times.Once());
+            settingsMock.Verify(settings => settings.SetValue(MobileCenter.EnabledKey, false), Times.Once());
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Mobile.Test
         {
             var settings = new DefaultApplicationSettings();
             var fakeInstallId = Guid.NewGuid();
-            settings[MobileCenter.InstallIdKey] = fakeInstallId;
+            settings.SetValue(MobileCenter.InstallIdKey, fakeInstallId);
             MobileCenter.Instance = new MobileCenter(settings);
             var installId = MobileCenter.GetInstallIdAsync().Result;
 

--- a/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterTest.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.Windows/MobileCenterTest.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Mobile.Test
         [TestMethod]
         public void GetInstallId()
         {
-            var settings = new ApplicationSettings();
+            var settings = new DefaultApplicationSettings();
             var fakeInstallId = Guid.NewGuid();
             settings[MobileCenter.InstallIdKey] = fakeInstallId;
             MobileCenter.Instance = new MobileCenter(settings);
@@ -343,7 +343,7 @@ namespace Microsoft.Azure.Mobile.Test
         public void LogUrlIsNotSetByDefault()
         {
             var channelGroupMock = new Mock<IChannelGroup>();
-            MobileCenter.Instance = new MobileCenter(new ApplicationSettings(),
+            MobileCenter.Instance = new MobileCenter(new DefaultApplicationSettings(),
                 new MockChannelGroupFactory(channelGroupMock));
             MobileCenter.Configure("appsecret");
             channelGroupMock.Verify(channelGroup => channelGroup.SetLogUrl(It.IsAny<string>()), Times.Never());
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.Mobile.Test
         public void SetLogUrlBeforeConfigure()
         {
             var channelGroupMock = new Mock<IChannelGroup>();
-            MobileCenter.Instance = new MobileCenter(new ApplicationSettings(),
+            MobileCenter.Instance = new MobileCenter(new DefaultApplicationSettings(),
                 new MockChannelGroupFactory(channelGroupMock));
             var customLogUrl = "www dot log url dot com";
             MobileCenter.SetLogUrl(customLogUrl);
@@ -372,7 +372,7 @@ namespace Microsoft.Azure.Mobile.Test
         public void SetLogUrlAfterConfigure()
         {
             var channelGroupMock = new Mock<IChannelGroup>();
-            MobileCenter.Instance = new MobileCenter(new ApplicationSettings(),
+            MobileCenter.Instance = new MobileCenter(new DefaultApplicationSettings(),
                 new MockChannelGroupFactory(channelGroupMock));
             MobileCenter.Configure("appsecret");
             var customLogUrl = "www dot log url dot com";

--- a/Tests/Microsoft.Azure.Mobile.Test.Windows/TestMobileCenterService.cs
+++ b/Tests/Microsoft.Azure.Mobile.Test.Windows/TestMobileCenterService.cs
@@ -5,13 +5,18 @@ namespace Microsoft.Azure.Mobile.Test.Windows
 {
     public class TestMobileCenterService : MobileCenterService
     {
-        public TestMobileCenterService(IApplicationSettings settings) : base(settings)
+        private readonly IApplicationSettings _settings;
+
+        public TestMobileCenterService(IApplicationSettings settings)
         {
+            _settings = settings;
         }
 
         public TestMobileCenterService()
         {
         }
+
+        protected override IApplicationSettings ApplicationSettings => _settings ?? base.ApplicationSettings;
 
         protected override string ChannelName => "test_service";
         public override string ServiceName => "TestService";


### PR DESCRIPTION
Needed to implement workaround for unity to avoid [known `IL2CPP` issue](https://issuetracker.unity3d.com/issues/il2cpp-use-of-windows-dot-foundation-dot-collections-dot-propertyset-throws-a-notsupportedexception-on-uwp):
```C#
NotSupportedException: Cannot call method 'System.Boolean System.Runtime.InteropServices.WindowsRuntime.IMapToIDictionaryAdapter`2::System.Collections.Generic.IDictionary`2.TryGetValue(TKey,TValue&)'. IL2CPP does not yet support calling this projected method.
  at System.Runtime.InteropServices.WindowsRuntime.IMapToIDictionaryAdapter`2[TKey,TValue].System.Collections.IEnumerable.GetEnumerator () [0x00000] in <00000000000000000000000000000000>:0 
  at Microsoft.Azure.Mobile.Utils.ApplicationSettings.GetValue[T] (System.String key, T defaultValue) [0x00000] in <00000000000000000000000000000000>:0 
  at Microsoft.Azure.Mobile.MobileCenter.get_InstanceEnabled () [0x00000] in <00000000000000000000000000000000>:0 
  at Microsoft.Azure.Mobile.MobileCenter.PlatformIsEnabledAsync () [0x00000] in <00000000000000000000000000000000>:0 
  at Microsoft.Azure.Mobile.MobileCenter.IsEnabledAsync () [0x00000] in <00000000000000000000000000000000>:0 
  at Microsoft.Azure.Mobile.Unity.Internal.MobileCenterInternal.IsEnabledAsync () [0x00000] in <00000000000000000000000000000000>:0 
  at Microsoft.Azure.Mobile.Unity.MobileCenter.IsEnabledAsync () [0x00000] in <00000000000000000000000000000000>:0 
  at PuppetMobileCenter.OnEnable () [0x00000] in <00000000000000000000000000000000>:0
```