### PR TITLE
Explicit set C# language version

### DIFF
--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Microsoft.Azure.Mobile.UWP.csproj
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.UWP/Microsoft.Azure.Mobile.UWP.csproj
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile/Microsoft.Azure.Mobile.csproj
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile/Microsoft.Azure.Mobile.csproj
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.Azure.Mobile.xml</DocumentationFile>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.UWP/Microsoft.Azure.Mobile.Analytics.UWP.csproj
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.UWP/Microsoft.Azure.Mobile.Analytics.UWP.csproj
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics/Microsoft.Azure.Mobile.Analytics.csproj
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics/Microsoft.Azure.Mobile.Analytics.csproj
@@ -25,6 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.Azure.Mobile.Analytics.xml</DocumentationFile>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.UWP/Microsoft.Azure.Mobile.Crashes.UWP.csproj
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.UWP/Microsoft.Azure.Mobile.Crashes.UWP.csproj
@@ -46,6 +46,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes/Microsoft.Azure.Mobile.Crashes.csproj
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes/Microsoft.Azure.Mobile.Crashes.csproj
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.Azure.Mobile.Crashes.xml</DocumentationFile>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute/Microsoft.Azure.Mobile.Distribute.csproj
+++ b/SDK/MobileCenterDistribute/Microsoft.Azure.Mobile.Distribute/Microsoft.Azure.Mobile.Distribute.csproj
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.Azure.Mobile.Distribute.xml</DocumentationFile>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/SDK/MobileCenterPush/Microsoft.Azure.Mobile.Push.UWP/Microsoft.Azure.Mobile.Push.UWP.csproj
+++ b/SDK/MobileCenterPush/Microsoft.Azure.Mobile.Push.UWP/Microsoft.Azure.Mobile.Push.UWP.csproj
@@ -92,6 +92,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>

--- a/SDK/MobileCenterPush/Microsoft.Azure.Mobile.Push/Microsoft.Azure.Mobile.Push.csproj
+++ b/SDK/MobileCenterPush/Microsoft.Azure.Mobile.Push/Microsoft.Azure.Mobile.Push.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.Azure.Mobile.Push.XML</DocumentationFile>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/Tests/Microsoft.Azure.Mobile.Analytics.NET/Microsoft.Azure.Mobile.Analytics.NET.csproj
+++ b/Tests/Microsoft.Azure.Mobile.Analytics.NET/Microsoft.Azure.Mobile.Analytics.NET.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/Microsoft.Azure.Mobile.Analytics.Test.Windows.csproj
+++ b/Tests/Microsoft.Azure.Mobile.Analytics.Test.Windows/Microsoft.Azure.Mobile.Analytics.Test.Windows.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests/Microsoft.Azure.Mobile.NET/Microsoft.Azure.Mobile.NET.csproj
+++ b/Tests/Microsoft.Azure.Mobile.NET/Microsoft.Azure.Mobile.NET.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Tests/Microsoft.Azure.Mobile.Push.NET/Microsoft.Azure.Mobile.Push.NET.csproj
+++ b/Tests/Microsoft.Azure.Mobile.Push.NET/Microsoft.Azure.Mobile.Push.NET.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests/Microsoft.Azure.Mobile.Push.Test.Windows/Microsoft.Azure.Mobile.Push.Test.Windows.csproj
+++ b/Tests/Microsoft.Azure.Mobile.Push.Test.Windows/Microsoft.Azure.Mobile.Push.Test.Windows.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests/Microsoft.Azure.Mobile.Test.UWP/Microsoft.Azure.Mobile.Test.UWP.csproj
+++ b/Tests/Microsoft.Azure.Mobile.Test.UWP/Microsoft.Azure.Mobile.Test.UWP.csproj
@@ -29,6 +29,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>

--- a/Tests/Microsoft.Azure.Mobile.Test.Windows/Microsoft.Azure.Mobile.Test.Windows.csproj
+++ b/Tests/Microsoft.Azure.Mobile.Test.Windows/Microsoft.Azure.Mobile.Test.Windows.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Since CI does not support C# 7, this allows preventing misuse it locally - disable IDE suggestions and get compile error like:
`Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.`